### PR TITLE
add Typescript typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Ilya Kozhevnikov <git@kozhevnikov.com>",
   "license": "MIT",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "files": [
     "index.js"
   ],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,11 @@
+declare module "proxymise" {
+  export type Proxymise<T> = {
+    [key in keyof T]: T[key] extends (
+      ...args: infer Params
+    ) => Promise<infer Return>
+      ? (...args: Params) => Proxymise<Return>
+      : T[key];
+  } & Promise<T>;
+
+  export default function <T>(target: T): Proxymise<T>;
+}


### PR DESCRIPTION
Adding types to play nicely with TS code bases. This allows wrapping a fluid API and the type will be correct:

```ts
const c = {
  testC: () => Promise.resolve("proxymised")
};

const b = {
  testB: () => Promise.resolve(c)
};

const a = {
  testA: () => Promise.resolve(b)
};

// TS does not complain
const result = await proxymise(a).testA().testB().testC().charAt(0);
```

Also allows to import proxymise:
```ts
import proxymise from "proxymise";
````

And you can type "proxymised" values:

```ts
import { Proxymise } from 'proxymise';

export class App {
   doSomething(): Proxymise<unknown> {
        // ...
    }
}
```
Code Sandbox to play with: https://codesandbox.io/s/proxymise-typescript-5rfrwv?file=/src/index.ts:0-391